### PR TITLE
Fix altDeploymentRepository id to match server credentials

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Deploy package
         if: ${{ inputs.central }}
         run: |
-          mvn --batch-mode deploy --activate-profiles release -DaltDeploymentRepository=id::njord: -Dnjord.autoPublish -Dnjord.publisher=sonatype-cp -Dnjord.publisher.sonatype-cp.releaseRepositoryId=sonatype-central-portal -Dnjord.publishingType=AUTOMATIC -Dnjord.waitForStates=true
+          mvn --batch-mode deploy --activate-profiles release -DaltDeploymentRepository=sonatype-central-portal::njord: -Dnjord.autoPublish -Dnjord.publisher=sonatype-cp -Dnjord.publisher.sonatype-cp.releaseRepositoryId=sonatype-central-portal -Dnjord.publishingType=AUTOMATIC -Dnjord.waitForStates=true
         env:
           MAVEN_USERNAME: ${{ secrets.username }}
           MAVEN_PASSWORD: ${{ secrets.password }}


### PR DESCRIPTION
## Summary
- The repository id in `-DaltDeploymentRepository=id::njord:` must match the `server-id` configured by `setup-java` (`sonatype-central-portal`), otherwise njord cannot find authorization credentials during auto-publish
- Changes `id` to `sonatype-central-portal` to match the server configuration

## Verified
This fix was verified by inlining the corrected workflow in [aemaacs-opentelemetry-instrumentation](https://github.com/orbinson/aemaacs-opentelemetry-instrumentation), which successfully released version 1.1.0 after applying this change.